### PR TITLE
add kind property for directory

### DIFF
--- a/denops/ddc-sources/file.ts
+++ b/denops/ddc-sources/file.ts
@@ -208,9 +208,9 @@ export class Source extends BaseSource {
               .take(p.takeFileNum)
               .filter(({ name }) => name.startsWith(inputBaseName))
               .map(({ name, isDirectory }): Candidate => ({
-                word: name +
-                  (isDirectory ? path.sep : ""),
+                word: name,
                 menu: (menu !== "" && isInputAbs ? path.sep : "") + menu,
+                kind: isDirectory ? "dir" : "",
               }))
               .take(Math.min(max, maxCandidates))
               .toArray()


### PR DESCRIPTION
I prefer to suggest child directory after inputting "/" for posix if selected item is directory.
We can distinguish which completion item is directory or not by "kind".
So, I remove path.sep.

How about this idea ?

![Kapture 2021-09-11 at 16 34 02](https://user-images.githubusercontent.com/212602/132940428-d3cb5bdb-5fdb-4c8f-87ce-9b3f49b67f37.gif)
