### PR TITLE
remove local ignoreCase option condition

### DIFF
--- a/denops/ddc-sources/file.ts
+++ b/denops/ddc-sources/file.ts
@@ -211,7 +211,9 @@ export class Source extends BaseSource {
                 [Symbol.asyncIterator](),
             )
               .take(p.takeFileNum)
-              .filter(({ name }) =>name.toUpperCase().startsWith(inputBaseName.toUpperCase()))
+              .filter(({ name }) =>
+                name.toUpperCase().startsWith(inputBaseName.toUpperCase())
+              )
               .map(({ name, isDirectory }): Candidate => ({
                 word: name,
                 menu: (menu !== "" && isInputAbs ? path.sep : "") + menu,

--- a/denops/ddc-sources/file.ts
+++ b/denops/ddc-sources/file.ts
@@ -208,9 +208,9 @@ export class Source extends BaseSource {
               .take(p.takeFileNum)
               .filter(({ name }) => name.startsWith(inputBaseName))
               .map(({ name, isDirectory }): Candidate => ({
-                word: name +
-                  (isDirectory ? path.sep : ""),
+                word: name,
                 menu: (menu !== "" && isInputAbs ? path.sep : "") + menu,
+                kind: isDirectory ? "dir" : "",
               }))
               .take(Math.min(max, maxCandidates))
               .toArray()

--- a/denops/ddc-sources/file.ts
+++ b/denops/ddc-sources/file.ts
@@ -49,7 +49,6 @@ export class Source extends BaseSource {
       : p.mode;
     const path = mode === "posix" ? univPath.posix : univPath.win32;
     const maxCandidates = args.sourceOptions.maxCandidates;
-    const ignoreCase = args.sourceOptions.ignoreCase;
     const maxOfMax = Math.max(
       p.cwdMaxCandidates,
       p.bufMaxCandidates,
@@ -212,11 +211,7 @@ export class Source extends BaseSource {
                 [Symbol.asyncIterator](),
             )
               .take(p.takeFileNum)
-              .filter(({ name }) =>
-                ignoreCase
-                  ? name.toUpperCase().startsWith(inputBaseName.toUpperCase())
-                  : name.startsWith(inputBaseName)
-              )
+              .filter(({ name }) =>name.toUpperCase().startsWith(inputBaseName.toUpperCase()))
               .map(({ name, isDirectory }): Candidate => ({
                 word: name,
                 menu: (menu !== "" && isInputAbs ? path.sep : "") + menu,


### PR DESCRIPTION
Maybe, this solution is better to work "ignoreCase" option.
Because of super Class(BaseSource) having ignoreCase option.

That bug was filter by "startsWith" before ignoreCase option by ddc core.
So,  my idea is that ,
1. changing both of name and inputBaseName for the upper case or lower case
2. filter by ignoreCase by ddc core

This PR is working both of global setting and local setting for "file".

Please check this.