### PR TITLE
Add `trailingSlashAbbr` param

### DIFF
--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -21,6 +21,7 @@ type Params = {
   bufAsRoot: boolean;
   projAsRoot: boolean;
   trailingSlash: boolean;
+  trailingSlashAbbr: boolean;
   followSymlinks: boolean;
   disableMenu: boolean;
 
@@ -239,6 +240,8 @@ export class Source extends BaseSource<Params> {
               .map(({ name, isDirectory, isSymlink }): Candidate => ({
                 word: name.slice(inputFileBasePrefix.length) +
                   (p.trailingSlash && isDirectory ? path.sep : ""),
+                abbr: name.slice(inputFileBasePrefix.length) +
+                  (p.trailingSlashAbbr && isDirectory ? path.sep : ""),
                 menu: p.disableMenu
                   ? undefined
                   : (menu !== "" && isInputAbs ? path.sep : "") + menu,
@@ -278,6 +281,7 @@ export class Source extends BaseSource<Params> {
       bufAsRoot: false,
       projAsRoot: true,
       trailingSlash: false,
+      trailingSlashAbbr: false,
       followSymlinks: false,
       disableMenu: false,
 

--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -281,7 +281,7 @@ export class Source extends BaseSource<Params> {
       bufAsRoot: false,
       projAsRoot: true,
       trailingSlash: false,
-      trailingSlashAbbr: false,
+      trailingSlashAbbr: true,
       followSymlinks: false,
       disableMenu: false,
 

--- a/doc/ddc-file.txt
+++ b/doc/ddc-file.txt
@@ -169,7 +169,7 @@ trailingSlashAbbr	(boolean)
 		Whether to display trailing slash when completing directory
 		name. Note that this won't be actually inserted.
 
-		Default: false
+		Default: true
 
 					      *ddc-file-params-followSymlinks*
 followSymlinks	(boolean)

--- a/doc/ddc-file.txt
+++ b/doc/ddc-file.txt
@@ -164,6 +164,13 @@ trailingSlash	(boolean)
 
 		Default: false
 
+					   *ddc-file-params-trailingSlashAbbr*
+trailingSlashAbbr	(boolean)
+		Whether to display trailing slash when completing directory
+		name. Note that this won't be actually inserted.
+
+		Default: false
+
 					      *ddc-file-params-followSymlinks*
 followSymlinks	(boolean)
 		Whether to follow symlinks to determine whether the filename


### PR DESCRIPTION
## Problem

When I enable `trailingSlash` sourceParam, it shows `/` at the end of directories at the completion popup, but it also inserts the `/` which prevents inputting next directory/file smoothly.

<a href="https://asciinema.org/a/kqe3LVUD2kQFOiuf01vMSha9O" target="_blank"><img src="https://asciinema.org/a/kqe3LVUD2kQFOiuf01vMSha9O.svg" /></a>

## Solution

Introduce `trailingSlashAbbr` to provide this functionality without breaking existing `trailingSlash`.

<a href="https://asciinema.org/a/7JvBigGxCF8lXQjXcr5unQRv1" target="_blank"><img src="https://asciinema.org/a/7JvBigGxCF8lXQjXcr5unQRv1.svg" /></a>


```vim
    " vimrc's ddc-file init_ddc() part
    call ddc#custom#patch_global('sourceOptions', {
          \ 'file': {
            \   'mark': 'F',
            \   'isVolatile': v:true,
            \   'forceCompletionPattern': '/\S*',
            \ }})
    call ddc#custom#patch_global('sourceParams', {
          \ 'file': {
            \   'trailingSlashAbbr': v:true,
            \ }})
```

## Acknowledge

Thanks @thinca and @shougo for helping me implementing this feature at a pair programming session.