### PR TITLE
Fix filename completions on a nonexisting file outside your home directory

### DIFF
--- a/autoload/ddc_file/internal.vim
+++ b/autoload/ddc_file/internal.vim
@@ -26,12 +26,7 @@ endfunction
 function! ddc_file#internal#info(input_line, is_posix) abort
   let input_file_full = s:line_to_file_full(a:input_line, a:is_posix)
   let input_file_base_prefix = s:full_to_base_prefix(input_file_full, a:is_posix)
-
-  if &buftype ==# '' && expand('%:p') !=# ''
-    let buf_path = expand('%:p')
-  else
-    let buf_path = getcwd() . '/dummy'
-  endif
+  let buf_path = expand('%:p')
 
   return [
       \ input_file_full,

--- a/autoload/ddc_file/internal.vim
+++ b/autoload/ddc_file/internal.vim
@@ -26,7 +26,13 @@ endfunction
 function! ddc_file#internal#info(input_line, is_posix) abort
   let input_file_full = s:line_to_file_full(a:input_line, a:is_posix)
   let input_file_base_prefix = s:full_to_base_prefix(input_file_full, a:is_posix)
-  let buf_path = expand('%:p')
+
+  if &buftype ==# '' && expand('%:p') !=# ''
+    let buf_path = expand('%:p')
+  else
+    let buf_path = getcwd() . '/dummy'
+  endif
+
   return [
       \ input_file_full,
       \ input_file_base_prefix,

--- a/autoload/ddc_file/internal.vim
+++ b/autoload/ddc_file/internal.vim
@@ -27,7 +27,6 @@ function! ddc_file#internal#info(input_line, is_posix) abort
   let input_file_full = s:line_to_file_full(a:input_line, a:is_posix)
   let input_file_base_prefix = s:full_to_base_prefix(input_file_full, a:is_posix)
   let buf_path = expand('%:p')
-
   return [
       \ input_file_full,
       \ input_file_base_prefix,

--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -139,7 +139,8 @@ export class Source extends BaseSource<Params> {
 
     // point from cwd
     findPointsAsync.push({
-      dir: Deno.cwd(),
+      // dir: Deno.cwd(),
+      dir: await args.denops.call("getcwd") as string,
       max: p.cwdMaxCandidates,
       menu: p.displayCwd,
       asRoot: p.cwdAsRoot,

--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -1,8 +1,8 @@
 import {
   BaseSource,
   Candidate,
-  GatherCandidatesArguments,
   fn,
+  GatherCandidatesArguments,
   homeDir,
   path as univPath,
   wrapA,

--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -138,9 +138,11 @@ export class Source extends BaseSource<Params> {
       });
     }
 
+    const dir = await fn.getcwd(args.denops) as string;
+
     // point from cwd
     findPointsAsync.push({
-      dir: await fn.getcwd(args.denops) as string,
+      dir: dir,
       max: p.cwdMaxCandidates,
       menu: p.displayCwd,
       asRoot: p.cwdAsRoot,
@@ -150,7 +152,7 @@ export class Source extends BaseSource<Params> {
     findPointsAsync.push(
       util.findMarkers(
         p.projFromCwdMaxCandidates.length,
-        Deno.cwd(),
+        dir,
         p.projMarkers,
         path,
       )

--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -138,11 +138,11 @@ export class Source extends BaseSource<Params> {
       });
     }
 
-    const dir = await fn.getcwd(args.denops) as string;
+    const cwd = await fn.getcwd(args.denops) as string;
 
     // point from cwd
     findPointsAsync.push({
-      dir: dir,
+      dir: cwd,
       max: p.cwdMaxCandidates,
       menu: p.displayCwd,
       asRoot: p.cwdAsRoot,
@@ -152,7 +152,7 @@ export class Source extends BaseSource<Params> {
     findPointsAsync.push(
       util.findMarkers(
         p.projFromCwdMaxCandidates.length,
-        dir,
+        cwd,
         p.projMarkers,
         path,
       )

--- a/denops/@ddc-sources/file.ts
+++ b/denops/@ddc-sources/file.ts
@@ -2,6 +2,7 @@ import {
   BaseSource,
   Candidate,
   GatherCandidatesArguments,
+  fn,
   homeDir,
   path as univPath,
   wrapA,
@@ -139,8 +140,7 @@ export class Source extends BaseSource<Params> {
 
     // point from cwd
     findPointsAsync.push({
-      // dir: Deno.cwd(),
-      dir: await args.denops.call("getcwd") as string,
+      dir: await fn.getcwd(args.denops) as string,
       max: p.cwdMaxCandidates,
       menu: p.displayCwd,
       asRoot: p.cwdAsRoot,


### PR DESCRIPTION
## Problem

ddc-file does not provide filenames when all of the following conditions have met:

* vim8
* not at a normal file (e.g. deol-edit buffer)
* not at your home directory

https://asciinema.org/a/rIvUFnqEAJhzm5stMSLu1KUUM

## Solution

This patch is not beautiful at all but it solves the problem.

https://asciinema.org/a/J3F5dGk85AOY8m6rxN5A1cVJE
